### PR TITLE
Replace missing method 'print_bracket_link' by 'print_button'

### DIFF
--- a/pages/import_issues.php
+++ b/pages/import_issues.php
@@ -394,7 +394,7 @@ if( $t_failure_count ) {
 	echo '<b>'.sprintf( plugin_lang_get( 'result_failure_ct' ), $t_failure_count) . ' :</b><br />';
    echo $t_error_messages . '<br/>';
 }
-print_bracket_link( $t_redirect_url, lang_get( 'proceed' ) );
+print_button( $t_redirect_url, lang_get( 'proceed' ) );
 ?>
 </div>
 </div>


### PR DESCRIPTION
`print_bracket_link()` is removed on mantisbt v2.11, replacing it by `print_button()`.

Related issue: https://mantisbt.org/bugs/view.php?id=23970
Related PR: https://github.com/mantisbt/mantisbt/pull/1259/files